### PR TITLE
Update default STT fallback to vosk

### DIFF
--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -61,7 +61,8 @@ cp -rf overlay/* / || exit 2
 cd /home/neon || exit 2
 
 # Install core and skills
-pip install "git+https://github.com/neongeckocom/neoncore@${CORE_REF:-dev}#egg=neon_core[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi,local,remote]" || exit 11
+pip install https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
+pip install "git+https://github.com/neongeckocom/neoncore@${CORE_REF:-dev}#egg=neon_core[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
 echo "Core Installed"
 neon-install-default-skills && echo "Default git skills installed" || exit 2
 

--- a/05_neon_core/overlay/etc/neon/neon.yaml
+++ b/05_neon_core/overlay/etc/neon/neon.yaml
@@ -19,7 +19,7 @@ audio_parsers:
   - gender
 stt:
   module: google_cloud_streaming
-  fallback_module: deepspeech_stream_local
+  fallback_module: ovos-stt-plugin-vosk
   ovos-stt-plugin-vosk:
     model: /home/neon/.local/share/neon/vosk-model-small-en-us-0.15
 confirm_listening: true


### PR DESCRIPTION
Update default fallback STT and update dependency handling for Python 3.10-compat. core dependencies