### PR TITLE
Fix core service start patching

### DIFF
--- a/automation/apply_patches.sh
+++ b/automation/apply_patches.sh
@@ -77,7 +77,7 @@ if grep -q "load-module module-combine-sink sink_name=OpenVoiceOS" /etc/pulse/sy
 fi
 
 # Check for old neon services
-if ! grep -q "TimeoutStopSec=60" /usr/lib/systemd/system/neon-speech.service; then
+if ! grep -q "TimeoutStartSec" /usr/lib/systemd/system/neon-speech.service; then
   echo "Patching Service Timeout"
   bash neon-image-recipe/patches/patch_service_timeout.sh
 fi


### PR DESCRIPTION
# Description
Implemented check would evaluate `True` in all cases. New check only evaluates to `True` if service has yet to be patched.

# Issues
Fix invalid service file check introduced in #84

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->