### PR TITLE
Add configuration checks to update validation

### DIFF
--- a/10_updater/overlay/opt/neon/check_neon_modules.py
+++ b/10_updater/overlay/opt/neon/check_neon_modules.py
@@ -34,8 +34,28 @@ try:
     from neon_gui.service import NeonGUIService
     from neon_speech.service import NeonSpeechClient
     from neon_enclosure.service import NeonHardwareAbstractionLayer
-    exit(0)
 except Exception as e:
     print(e)
     print("Modules failed to load")
+    exit(2)
+
+
+from neon_core.util.runtime_utils import use_neon_core
+
+
+@use_neon_core
+def check_configuration():
+    from ovos_config.config import Configuration
+    for config_path in [Configuration.default.path,
+                        Configuration.system.path]:
+        print(config_path)
+        assert config_path.endswith("/neon.yaml")
+
+
+try:
+    check_configuration()
+    print("Configuration validated")
+except Exception as e:
+    print(e)
+    print("Configuration check failed")
     exit(2)

--- a/automation/apply_patches.sh
+++ b/automation/apply_patches.sh
@@ -110,6 +110,12 @@ if [ ! -f /home/neon/.local/share/neon/hey-mycroft.pb ]; then
   bash neon-image-recipe/patches/get_precise_binary.sh
 fi
 
+# Patch update config validation
+if ! grep -q "def check_configuration" /opt/neon/check_neon_modules.py; then
+  echo "Patching configuration check"
+  bash neon-image-recipe/patches/patch_update_configuration_check.sh
+fi
+
 # Remove web_cache config
 if [ -f /home/neon/.config/neon/web_cache.json ]; then
   echo "Removing web_cache.json"

--- a/patches/patch_poweroff_script.sh
+++ b/patches/patch_poweroff_script.sh
@@ -36,6 +36,6 @@ cd "${BASE_DIR}" || exit 10
 
 sudo cp ../03_sj201/overlay/opt/neon/poweroff.sh /opt/neon/poweroff.sh
 sudo chmod ugo+x /opt/neon/poweroff.sh
-sudo rm -rf neon-image-recipe
+
 sudo systemctl daemon-reload
 echo "poweroff script updated"


### PR DESCRIPTION
# Description
Include more validation that configuration will properly load after applied updates

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This relates to some debugging of breaking updates in ovos-utils being applied to Neon 22.10.3, but did not entirely resolve the issue