### PR TITLE
Fix logical error in `update` patch check

### DIFF
--- a/automation/apply_patches.sh
+++ b/automation/apply_patches.sh
@@ -113,7 +113,7 @@ if [ -f /home/neon/.config/neon/web_cache.json ]; then
 fi
 
 # Check for patched update script
-if ! grep -q "# Applied Patch " /opt/neon/update; then
+if grep -q "# Applied Patch " /opt/neon/update; then
   echo "Overwriting Patched Update Script"
   cp neon-image-recipe/10_updater/overlay/opt/neon/update /opt/neon/update
 chmod ugo+x /opt/neon/update


### PR DESCRIPTION
# Description
Previous check had inverted logic in checking for a patched update script

# Issues
This was patched in 23.3.15 branch: https://github.com/NeonGeckoCom/neon-image-recipe/commit/f8b24bc1925618ed6973ce28251057c2d6714fba

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->