### PR TITLE
Extend skills service stop timeout

### DIFF
--- a/05_neon_core/overlay/usr/lib/systemd/system/neon-skills.service
+++ b/05_neon_core/overlay/usr/lib/systemd/system/neon-skills.service
@@ -7,7 +7,7 @@ After=neon-bus.service
 [Service]
 Type=notify
 TimeoutStartSec=600
-TimeoutStopSec=60
+TimeoutStopSec=90
 Restart=always
 User=neon
 WorkingDirectory=/opt/neon


### PR DESCRIPTION
# Description
Extend stop timeout for skills service to prevent killing process during shutdown

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->