### PR TITLE
Update default VAD plugin

### DIFF
--- a/05_neon_core/overlay/etc/neon/neon.yaml
+++ b/05_neon_core/overlay/etc/neon/neon.yaml
@@ -26,7 +26,7 @@ confirm_listening: true
 listener:
   VAD:
     silence_method: vad_only
-    module: ovos-vad-plugin-webrtcvad
+    module: ovos-vad-plugin-silero
   mute_during_output: false
   instant_listen: true
 hotwords:


### PR DESCRIPTION
# Description
Update default VAD module to `silero` to work around undiagnosed WebRTC errors on some installations

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->