### PR TITLE
Patches for 23.7.20

### DIFF
--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -90,16 +90,17 @@ rm precise-engine_0.3.0_aarch64.tar.gz
 cd neon || exit 10
 wget https://github.com/MycroftAI/precise-data/raw/models-dev/hey-mycroft.tar.gz
 tar xvf hey-mycroft.tar.gz && echo "ww model unpacked"
+rm -rf hey-mycroft.tar.gz
 
 export XDG_CONFIG_HOME="/home/neon/.config"
 export XDG_DATA_HOME="/home/neon/.local/share"
 export XDG_CACHE_HOME="/home/neon/.cache"
 
-rm -rf /home/neon/.cache/pip
-apt clean
+rm -rf /home/neon/.cache/pip && echo "cleared pip cache" || echo "no pip cache to clear``"
+apt clean && echo "cleaned apt caches" || echo "failed to clear apt cache"
 
 # TODO: Unknown patching
-rm /home/neon/.local/share/neon/qemu_*
+rm /home/neon/.local/share/neon/qemu_* || echo "no qemu file to clean"
 
 # TODO: Below init neon_core default fallbacks but CLIs should add an option to init configured fallbacks
 # Init TTS model

--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -95,6 +95,9 @@ export XDG_CONFIG_HOME="/home/neon/.config"
 export XDG_DATA_HOME="/home/neon/.local/share"
 export XDG_CACHE_HOME="/home/neon/.cache"
 
+rm -rf /home/neon/.cache/pip
+apt clean
+
 # TODO: Unknown patching
 rm /home/neon/.local/share/neon/qemu_*
 

--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -63,7 +63,7 @@ cd /home/neon || exit 2
 # Install core and skills
 #pip install https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
 export NEON_IN_SETUP="true"
-pip install "git+https://github.com/openvoiceos/ovos-config@FIX_InfinitelyRecursiveCallback"  # TODO: 23.7.20 Patch
+pip install ovos-config==0.0.11a5  # TODO: 23.7.20 Patch
 pip install "git+https://github.com/neongeckocom/neoncore@${CORE_REF:-dev}#egg=neon_core[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
 echo "Core Installed"
 neon-install-default-skills && echo "Default git skills installed" || exit 2

--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -63,8 +63,8 @@ cd /home/neon || exit 2
 # Install core and skills
 #pip install https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
 export NEON_IN_SETUP="true"
-pip install ovos-config==0.0.11a5  # TODO: 23.7.20 Patch
-pip install "git+https://github.com/neongeckocom/neoncore@${CORE_REF:-dev}#egg=neon_core[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
+# TODO: ovos-config 23.7.20 Patch
+pip install ovos-config==0.0.11a5 "git+https://github.com/neongeckocom/neoncore@${CORE_REF:-dev}#egg=neon_core[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
 echo "Core Installed"
 neon-install-default-skills && echo "Default git skills installed" || exit 2
 
@@ -94,6 +94,9 @@ tar xvf hey-mycroft.tar.gz && echo "ww model unpacked"
 export XDG_CONFIG_HOME="/home/neon/.config"
 export XDG_DATA_HOME="/home/neon/.local/share"
 export XDG_CACHE_HOME="/home/neon/.cache"
+
+# TODO: Unknown patching
+rm /home/neon/.local/share/neon/qemu_*
 
 # TODO: Below init neon_core default fallbacks but CLIs should add an option to init configured fallbacks
 # Init TTS model

--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -61,7 +61,7 @@ cp -rf overlay/* / || exit 2
 cd /home/neon || exit 2
 
 # Install core and skills
-pip install https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
+#pip install https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
 export NEON_IN_SETUP="true"
 pip install "git+https://github.com/openvoiceos/ovos-config@FIX_InfinitelyRecursiveCallback"  # TODO: 23.7.20 Patch
 pip install "git+https://github.com/neongeckocom/neoncore@${CORE_REF:-dev}#egg=neon_core[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11

--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -83,9 +83,9 @@ wget -O /home/neon/.local/share/precise-lite/hey_mycroft.tflite https://github.c
 
 # Precise engine and models
 cd /home/neon/.local/share || exit 10
-wget https://github.com/MycroftAI/mycroft-precise/releases/download/v0.3.0/precise-engine_0.3.0_aarch64.tar.gz
-tar xvf precise-engine_0.3.0_aarch64.tar.gz && echo "precise engine unpacked"
-rm precise-engine_0.3.0_aarch64.tar.gz
+#wget https://github.com/MycroftAI/mycroft-precise/releases/download/v0.3.0/precise-engine_0.3.0_aarch64.tar.gz
+#tar xvf precise-engine_0.3.0_aarch64.tar.gz && echo "precise engine unpacked"
+#rm precise-engine_0.3.0_aarch64.tar.gz
 
 cd neon || exit 10
 wget https://github.com/MycroftAI/precise-data/raw/models-dev/hey-mycroft.tar.gz
@@ -98,9 +98,6 @@ export XDG_CACHE_HOME="/home/neon/.cache"
 
 rm -rf /home/neon/.cache/pip && echo "cleared pip cache" || echo "no pip cache to clear``"
 apt clean && echo "cleaned apt caches" || echo "failed to clear apt cache"
-
-# TODO: Unknown patching
-rm /home/neon/.local/share/neon/qemu_* || echo "no qemu file to clean"
 
 # TODO: Below init neon_core default fallbacks but CLIs should add an option to init configured fallbacks
 # Init TTS model

--- a/05_neon_core/install_requirements.sh
+++ b/05_neon_core/install_requirements.sh
@@ -63,6 +63,7 @@ cd /home/neon || exit 2
 # Install core and skills
 pip install https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-cp37-cp37m-linux_aarch64.whl
 export NEON_IN_SETUP="true"
+pip install "git+https://github.com/openvoiceos/ovos-config@FIX_InfinitelyRecursiveCallback"  # TODO: 23.7.20 Patch
 pip install "git+https://github.com/neongeckocom/neoncore@${CORE_REF:-dev}#egg=neon_core[core_modules,skills_required,skills_essential,skills_default,skills_extended,pi]" || exit 11
 echo "Core Installed"
 neon-install-default-skills && echo "Default git skills installed" || exit 2

--- a/05_neon_core/overlay/etc/systemd/journald.conf
+++ b/05_neon_core/overlay/etc/systemd/journald.conf
@@ -1,4 +1,0 @@
-[Journal]
-Storage=volatile
-Compress=yes
-SystemMaxUse=50M

--- a/11_factory_reset/configure_reset.sh
+++ b/11_factory_reset/configure_reset.sh
@@ -36,6 +36,9 @@ cp -rf overlay/* / || exit 2
 # Ensure executable
 chmod +x /opt/neon/reset
 
+# TODO: Unknown patching
+rm /home/neon/.local/share/neon/qemu_*
+
 # Copy default files to backup location
 cp -r /home/neon /opt/neon/backup
 

--- a/automation/run_scripts.sh
+++ b/automation/run_scripts.sh
@@ -88,7 +88,7 @@ if [ "${1}" == "all" ]; then
     fi
     bash 04_embedded_shell/install_gui_shell.sh
     bash 05_neon_core/install_requirements.sh
-    bash 06_dashboard/install_ovos_dashboard.sh
+#    bash 06_dashboard/install_ovos_dashboard.sh
     if [ "${dist}" == 'Ubuntu' ]; then
         bash 07_camera/configure_camera.sh
         bash 08_splash_screen/configure_splash.sh


### PR DESCRIPTION
# Description
Patches ovos-config for Neon 23.7.20
Removes extra installation of deepspeech and dashboard that are no longer used

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->